### PR TITLE
Update configuration requirements for access keys

### DIFF
--- a/docs/quobyte_access_keys.md
+++ b/docs/quobyte_access_keys.md
@@ -10,7 +10,8 @@ Requires Quobyte version 3.1 or later
 
 To enable volume mount protection:
 
-1. Quobyte clients must be deployed with `enable-access-contexts` option
+1. Quobyte client(s) must be deployed with `--enable-access-contexts` and
+  `--no-default-permissions` options (see [example client](../example/client.yaml))
 2. Quobyte CSI driver must be deployed with `enableAccessKeyMounts: true`
 
 ## Storage Access with Access Keys

--- a/example/client.yaml
+++ b/example/client.yaml
@@ -60,7 +60,7 @@ spec:
           - |
             ENABLE_ACCESS_CONTEXTS=""
             if [[ ${ENABLE_ACCESS_KEY_MOUNTS} = true ]]; then
-              ENABLE_ACCESS_CONTEXTS="--enable-access-contexts"
+              ENABLE_ACCESS_CONTEXTS="--enable-access-contexts --no-default-permissions"
             fi
             if cut -d" " -f2 /proc/self/mounts | grep -q ${QUOBYTE_MOUNT_POINT}; then
               umount -l ${QUOBYTE_MOUNT_POINT}


### PR DESCRIPTION
When access keys are used, quobyte client should be started with --enable-access-contexts and --no-default-permissions options. This patch updates the documentation and example client configuration to reflect these requirements.