### PR TITLE
Add missing error handling for volume expansion

### DIFF
--- a/src/driver/controller.go
+++ b/src/driver/controller.go
@@ -505,6 +505,8 @@ func (d *QuobyteDriver) ListSnapshots(ctx context.Context, req *csi.ListSnapshot
 
 func (d *QuobyteDriver) ControllerExpandVolume(ctx context.Context, req *csi.ControllerExpandVolumeRequest) (*csi.ControllerExpandVolumeResponse, error) {
 	capacity := req.CapacityRange.RequiredBytes
-	d.expandVolume(&ExpandVolumeReq{volID: req.VolumeId, expandSecrets: req.Secrets, capacity: capacity})
+	if err := d.expandVolume(&ExpandVolumeReq{volID: req.VolumeId, expandSecrets: req.Secrets, capacity: capacity}); err != nil {
+		return nil, err
+	}
 	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacity}, nil
 }

--- a/src/driver/utils.go
+++ b/src/driver/utils.go
@@ -67,6 +67,9 @@ func (d *QuobyteDriver) expandVolume(req *ExpandVolumeReq) error {
 		return fmt.Errorf("controller-expand-secret-name and controller-expand-secret-namespace should be configured")
 	}
 	quobyteClient, err := d.getQuobyteApiClient(secrets)
+	if err != nil {
+		return err
+	}
 	capacity := req.capacity
 	volUUID, err := quobyteClient.GetVolumeUUID(volParts[1], volParts[0])
 	if err != nil {


### PR DESCRIPTION
This PR adds missing error handling for volume expansion. It fixes the following potential bugs.

1. Because ControllerExpandVolume ignores errors, it might cause inconsistency between a PVC and a Quobyte Volume.
1. When the controller-expand-secret lacks keys, the quobyte-csi controller will panic.