### PR TITLE
Reflect change of file extension in doc

### DIFF
--- a/docs/collect_quobyte_csi_logs.md
+++ b/docs/collect_quobyte_csi_logs.md
@@ -6,15 +6,15 @@ Log collector gathers logs from all the Quobyte CSI containers in single place f
 1. Get the log_collector utility script on any node with working kubectl
 
     ```bash
-    wget https://raw.githubusercontent.com/quobyte/quobyte-csi/master/log_collector \
-     && chmod +x log_collector
+    wget https://raw.githubusercontent.com/quobyte/quobyte-csi/master/log_collector.sh \
+     && chmod +x log_collector.sh
      
     ```
 
 2. Run the log_collector
 
     ```bash
-    ./log_collector
+    ./log_collector.sh
     ```
 
 3. Logs can be found under the directory `./csi_logs` for analysis.


### PR DESCRIPTION
As log collector is a bash script, it was renamed
and added with extension. However, that change was not reflected in the documentation. So, update doc.