### PR TITLE
Pod killer fixes

### DIFF
--- a/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
@@ -14,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
-  replicas: 1
+  replicas: {{ .Values.quobyte.podKiller.cacheReplicas }}
   template:
     metadata:
       labels:

--- a/csi-driver-templates/tests/README.md
+++ b/csi-driver-templates/tests/README.md
@@ -2,12 +2,11 @@
 
 To run Helm unit tests a helm plugin is needed:
 
-```
+```bash
 helm plugin install https://github.com/quintush/helm-unittest 
 ```
 
-
-* cd to root of the project `cd ../..`
+* cd to root of the project
 * Run `helm unittest -3 ./csi-driver-templates` to run tests
   * Verify that failure is due to new changes that were added to the template files.
     If this the case, update template snapshot with `helm unittest -3 -u ./csi-driver-templates`

--- a/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -591,7 +591,7 @@ should render when resource limits are provided:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-mount-monitor
             resources:
@@ -692,7 +692,7 @@ should render when resource limits are provided:
           - args:
             - --driver_name=csi.quobyte.com
             - --role=cache
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-pod-killer-cache
             ports:
@@ -1212,7 +1212,7 @@ should render when tolerations are provided:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-mount-monitor
             securityContext:
@@ -1313,7 +1313,7 @@ should render when tolerations are provided:
           - args:
             - --driver_name=csi.quobyte.com
             - --role=cache
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-pod-killer-cache
             ports:
@@ -1829,7 +1829,7 @@ should render with default values:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-mount-monitor
             securityContext:
@@ -1926,7 +1926,7 @@ should render with default values:
           - args:
             - --driver_name=csi.quobyte.com
             - --role=cache
-            image: quay.io/quobyte/pod-killer:v0.2.0
+            image: quay.io/quobyte/pod-killer:v0.2.1
             imagePullPolicy: IfNotPresent
             name: quobyte-csi-pod-killer-cache
             ports:

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -81,7 +81,7 @@ quobyte:
     # github.com/quobyte/quobyte-csi
     csiImage: "quay.io/quobyte/csi:v2.1.0"
     # github.com/quobyte/pod-killer
-    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.0"
+    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.1"
     # k8s sidecar containers (https://github.com/kubernetes-csi/)
     # Updating k8s...Image might require RBAC files update
     # https://github.com/quobyte/quobyte-csi/tree/master/quobyte-csi-driver/templates/pods/rbac

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -69,6 +69,8 @@ quobyte:
     enable: true
     # should be a valid golang time.Duration
     monitoringInterval: 5s
+    # At least one of the pod killer cache replica should be running for pod killer to work
+    cacheReplicas: 1
 
   # The dev configuration is intended for Quobyte Developers and internal use.
   # Please do NOT change the dev: configuration unless otherwise advised to change.

--- a/kind-cluster/README.md
+++ b/kind-cluster/README.md
@@ -16,6 +16,15 @@ The aim of these set of scripts is to enable CSI e2e test runs against internal 
 
 5. Quobyte API endpoint and registry endpoint
 
+6. Checkout [Quobyte CSI Pod Killer](https://github.com/quobyte/quobyte-csi-pod-killer) at the same
+ level in directory as Quobyte CSI Driver and change to required branch of `quobyte-csi-pod-killer`
+
+    ```bash
+    $ls
+    quobyte-csi-driver/
+    quobyte-csi-pod-killer/
+    ```
+
 ## Run tests
 
 1. Clone `quobyte-csi` repo & checkout a feature branch
@@ -37,6 +46,11 @@ The aim of these set of scripts is to enable CSI e2e test runs against internal 
     You can also run `kind-cluster/run_test` without `TEST_CASE_DIR` to provision a kubernetes cluster
     . Thereafter, you could `export KUBECONFIG=...` as instructed by script output and install
     csi driver, execute tests manually.
+
+    or
+
+    You can run with `TEST_CASE_DIR` that contains only CSI driver values.yaml to deploy the driver
+    (note that some defined values such as CSI image/pod killer images are overriden)
 
 ## Cleanup
 

--- a/kind-cluster/run_test
+++ b/kind-cluster/run_test
@@ -3,6 +3,7 @@
 MOUNT_WITH_ACCESS_KEYS=${MOUNT_WITH_ACCESS_KEYS:-n}
 PATH="$(pwd):$PATH"
 CODE_BASE_DIR="$(pwd)"
+POD_KILLER_DIR="$(pwd)/../quobyte-csi-pod-killer"
 TEST_CASE_DIR="${TEST_CASE_DIR:-}"
 KIND_CLUSTER_NAME="quobyte-csi-testing"
 TEST_CLUSTER_DIR='kind-cluster/kind-csi-testing'
@@ -21,6 +22,26 @@ if [ ! -z "$(git status --porcelain)" ]; then
   exit 1
 fi
 
+if [ ! -d "${POD_KILLER_DIR}" ]; then
+  die "Pod killer code base does not exists in the path ${POD_KILLER_DIR}"
+fi
+
+echo "*** Building pod killer ***"
+cd ${POD_KILLER_DIR}
+POD_KILLER_VERSION="$(git rev-parse --short HEAD)"
+POD_KILLER_CONTAINER_URL_BASE="dummy.quobyte.com/pod-killer"
+POD_KILLER_IMAGE="${POD_KILLER_CONTAINER_URL_BASE}:${POD_KILLER_VERSION}"
+${POD_KILLER_DIR}/build
+docker build -t ${POD_KILLER_IMAGE} -f Dockerfile .
+pod_killer_container_build_status=$?
+
+if [[ "${pod_killer_container_build_status}" -ne 0 ]]; then
+  die "Failed building pod killer container"
+else
+  echo "Successfully build pod killer image $POD_KILLER_IMAGE"
+fi
+
+cd $CODE_BASE_DIR
 if [[ -f "$KUBECONFIG" ]]; then
   rm "$KUBECONFIG"
 fi
@@ -129,6 +150,7 @@ if [[ "$?" -ne 0 ]]; then
   exit 1
 fi
 kind load docker-image ${CSI_DRIVER_IMAGE} --name ${KIND_CLUSTER_NAME}
+kind load docker-image ${POD_KILLER_IMAGE} --name ${KIND_CLUSTER_NAME}
 
 echo "creating and setting default namespace to quobyte * * * * * * * * * * * *" 
 #to retrieve instances from all namespaces use '-A' argument
@@ -200,12 +222,21 @@ for file in ${TEST_CASE_DIR}/k8s_*.yaml ; do kubectl apply -f "$file"; done
 
 sleep 30s
 
+if [[ ! -f "${TEST_CASE_DIR}/values.yaml" ]]; then
+  die "${TEST_CASE_DIR}/values.yaml not found. Cannot setup Quobyte CSI Driver."
+fi
+
 echo ""
-echo "Deploying CSI Driver with $TEST_CASE_DIR/values.yaml and quobyte.dev.csiImage set to $CSI_DRIVER_IMAGE"
+echo "Deploying CSI Driver with $TEST_CASE_DIR/values.yaml with overrides \
+      quobyte.dev.csiProvisionerVersion=$CSI_DRIVER_VERSION \
+      quobyte.dev.csiImage=$CSI_DRIVER_IMAGE \
+      quobyte.dev.podKillerImage=$POD_KILLER_IMAGE \
+      quobyte.csiProvisionerName=$CSI_PROVISIONER_NAME"
 # install CSI driver with the custom image
 helm install quobyte-csi-driver ./csi-driver-templates -f ${TEST_CASE_DIR}/values.yaml \
  --set quobyte.dev.csiProvisionerVersion="$CSI_DRIVER_VERSION" \
  --set quobyte.dev.csiImage="$CSI_DRIVER_IMAGE" \
+ --set quobyte.dev.podKillerImage="$POD_KILLER_IMAGE" \
  --set quobyte.csiProvisionerName="$CSI_PROVISIONER_NAME"
 
 sleep 1m
@@ -220,6 +251,10 @@ if [[ "$enabled_snapshots" -eq 0 ]]; then
 fi
 
 echo ""
+if [[ ! -f "$TEST_CASE_DIR/k8s_storage_class.yaml" ]]; then
+  echo "No k8s_storage_class.yaml exists in the given test path $TEST_CASE_DIR. So not running e2e tests"
+  exit 0  # success as driver is setup with given values.yaml 
+fi
 echo "Running e2e tests the storage class in $TEST_CASE_DIR/k8s_storage_class.yaml"
 STORAGE_CLASS="$TEST_CASE_DIR/k8s_storage_class.yaml" KUBECONFIG="$KUBECONFIG" \
  SNAPSHOT_CLASS="$TEST_CASE_DIR/k8s_volume-snapshot-class.yaml" \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
-RUN apt-get -y update && apt-get -y upgrade && apt-get install -y attr
+RUN apt-get -y update && apt-get -y upgrade && apt-get install -y attr \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 ADD quobyte-csi /bin
 


### PR DESCRIPTION
* Pod killer replicas can be configurable to support rolling upgrade scenarios
* Bumped pod killer to v0.2.1 that includes sticky cache critical fix
* Removed base image package caches to reduce the image size
* Improved kind test setup to pick pod killer automatically