### PR TITLE
Use who am i and other improvements

### DIFF
--- a/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
+++ b/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
@@ -9,8 +9,8 @@
   securityContext:
     privileged: true
     capabilities:
-      add: ["SYS_ADMIN"]
-    allowPrivilegeEscalation: true
+      # For shared volume PVCs, ownership change is required      
+      add: ["SYS_ADMIN", "CHOWN"]
   image: {{ .Values.quobyte.dev.csiImage }}
   imagePullPolicy: "IfNotPresent"
   args:
@@ -53,4 +53,10 @@
     - name: certs
       mountPath: /etc/ssl/certs/
     {{- end }}
+    - name: users
+      mountPath: /etc/passwd
+      mountPropagation: "HostToContainer"
+    - name: groups
+      mountPath: /etc/group
+      mountPropagation: "HostToContainer"
 {{- end }}

--- a/csi-driver-templates/templates/pods/containers/_quobyte_csi_node_driver_container.tpl
+++ b/csi-driver-templates/templates/pods/containers/_quobyte_csi_node_driver_container.tpl
@@ -56,4 +56,10 @@
     - name: certs
       mountPath: /etc/ssl/certs/
     {{- end }}
+    - name: users
+      mountPath: /etc/passwd
+      mountPropagation: "HostToContainer"
+    - name: groups
+      mountPath: /etc/group
+      mountPropagation: "HostToContainer"
 {{- end}}

--- a/csi-driver-templates/templates/pods/volumes/_quobyte_csi_controller_volume_attachments.tpl
+++ b/csi-driver-templates/templates/pods/volumes/_quobyte_csi_controller_volume_attachments.tpl
@@ -17,4 +17,12 @@ volumes:
       path: /etc/ssl/certs/
       type: Directory
   {{- end }}
+  - name: users
+    hostPath:
+      path: /etc/passwd
+      type: File
+  - name: groups
+    hostPath:
+      path: /etc/group
+      type: File
 {{- end }}

--- a/csi-driver-templates/templates/pods/volumes/_quobyte_csi_node_plugin_volume_attachments.tpl
+++ b/csi-driver-templates/templates/pods/volumes/_quobyte_csi_node_plugin_volume_attachments.tpl
@@ -28,4 +28,12 @@ volumes:
       path: /etc/ssl/certs/
       type: Directory
   {{- end }}
+  - name: users
+    hostPath:
+      path: /etc/passwd
+      type: File
+  - name: groups
+    hostPath:
+      path: /etc/group
+      type: File
 {{- end }}

--- a/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -396,10 +396,10 @@ should render when resource limits are provided:
                   cpu: 50m
                   memory: 50Mi
               securityContext:
-                allowPrivilegeEscalation: true
                 capabilities:
                   add:
                     - SYS_ADMIN
+                    - CHOWN
                 privileged: true
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -411,6 +411,12 @@ should render when resource limits are provided:
                   name: quobyte-mounts
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
           priorityClassName: system-cluster-critical
           serviceAccount: quobyte-csi-controller-sa-csi-quobyte-com
           volumes:
@@ -428,6 +434,14 @@ should render when resource limits are provided:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   12: |
     apiVersion: v1
     kind: ServiceAccount
@@ -573,6 +587,12 @@ should render when resource limits are provided:
                   name: log-dir
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
             - args:
                 - --node_name=$(KUBE_NODE_NAME)
                 - --driver_name=csi.quobyte.com
@@ -633,6 +653,14 @@ should render when resource limits are provided:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   16: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1022,10 +1050,10 @@ should render when tolerations are provided:
               imagePullPolicy: IfNotPresent
               name: quobyte-csi-driver
               securityContext:
-                allowPrivilegeEscalation: true
                 capabilities:
                   add:
                     - SYS_ADMIN
+                    - CHOWN
                 privileged: true
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -1037,6 +1065,12 @@ should render when tolerations are provided:
                   name: quobyte-mounts
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
           priorityClassName: system-cluster-critical
           serviceAccount: quobyte-csi-controller-sa-csi-quobyte-com
           tolerations:
@@ -1058,6 +1092,14 @@ should render when tolerations are provided:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   10: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1195,6 +1237,12 @@ should render when tolerations are provided:
                   name: log-dir
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
             - args:
                 - --node_name=$(KUBE_NODE_NAME)
                 - --driver_name=csi.quobyte.com
@@ -1255,6 +1303,14 @@ should render when tolerations are provided:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   14: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1644,10 +1700,10 @@ should render with default values:
               imagePullPolicy: IfNotPresent
               name: quobyte-csi-driver
               securityContext:
-                allowPrivilegeEscalation: true
                 capabilities:
                   add:
                     - SYS_ADMIN
+                    - CHOWN
                 privileged: true
               volumeMounts:
                 - mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -1659,6 +1715,12 @@ should render with default values:
                   name: quobyte-mounts
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
           priorityClassName: system-cluster-critical
           serviceAccount: quobyte-csi-controller-sa-csi-quobyte-com
           volumes:
@@ -1676,6 +1738,14 @@ should render with default values:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   10: |
     apiVersion: v1
     kind: ServiceAccount
@@ -1813,6 +1883,12 @@ should render with default values:
                   name: log-dir
                 - mountPath: /etc/ssl/certs/
                   name: certs
+                - mountPath: /etc/passwd
+                  mountPropagation: HostToContainer
+                  name: users
+                - mountPath: /etc/group
+                  mountPropagation: HostToContainer
+                  name: groups
             - args:
                 - --node_name=$(KUBE_NODE_NAME)
                 - --driver_name=csi.quobyte.com
@@ -1869,6 +1945,14 @@ should render with default values:
                 path: /etc/ssl/certs/
                 type: Directory
               name: certs
+            - hostPath:
+                path: /etc/passwd
+                type: File
+              name: users
+            - hostPath:
+                path: /etc/group
+                type: File
+              name: groups
   14: |
     apiVersion: v1
     kind: ServiceAccount

--- a/example/Storage-class-shared-volume.yaml
+++ b/example/Storage-class-shared-volume.yaml
@@ -36,6 +36,8 @@ parameters:
   # creates quota for the volume if set to true. The size of the Quota
   # is the storage requested in PVC. If false, creates volume without size limit.
   createQuota: "true"
+  # user/group is optional - if not provided, user/group is retrieved from the Quobyte user
+  # associated with the provisioner-secret provided above.
   user: root
   group: root
   accessMode: "777"

--- a/example/StorageClass.yaml
+++ b/example/StorageClass.yaml
@@ -35,6 +35,8 @@ parameters:
   # creates quota for the volume if set to true. The size of the Quota
   # is the storage requested in PVC. If false, creates volume without size limit.
   createQuota: "true"
+  # user/group is optional - if not provided, user/group is retrieved from the Quobyte user
+  # associated with the provisioner-secret provided above.
   user: nginx
   group: nginx
   accessMode: "750"

--- a/example/access_keys/storage-class-api-and-mount-secret.yaml
+++ b/example/access_keys/storage-class-api-and-mount-secret.yaml
@@ -19,7 +19,9 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-name: "quobyte-mount-secret"
   csi.storage.k8s.io/node-publish-secret-namespace: "quobyte"
   createQuota: "true"
+  # user/group is optional - if not provided, user/group is retrieved from the Quobyte user
+  # associated with the provisioner-secret provided above.
   user: root
   group: root
-  accessMode: "777"
+  accessMode: "750"
 reclaimPolicy: Delete

--- a/example/access_keys/storage-class-generic-secret.yaml
+++ b/example/access_keys/storage-class-generic-secret.yaml
@@ -19,7 +19,9 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-name: "quobyte-generic-secret"
   csi.storage.k8s.io/node-publish-secret-namespace: "quobyte"
   createQuota: "true"
+  # user/group is optional - if not provided, user/group is retrieved from the Quobyte user
+  # associated with the provisioner-secret provided above.
   user: root
   group: root
-  accessMode: "777"
+  accessMode: "750"
 reclaimPolicy: Delete

--- a/example/client.yaml
+++ b/example/client.yaml
@@ -26,7 +26,7 @@ spec:
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2169 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -94,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -109,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/run_test
+++ b/kind-cluster/run_test
@@ -64,8 +64,12 @@ echo "Running script from $(pwd)"
 echo "Creating kind k8s cluster Dockerfile * * * * * * * * *  * * * * * * * * * * * * * * * * *"
 echo ""
 echo ""
+
+# https://github.com/kubernetes-sigs/kind/releases
+# Install the latest kind binary from the releases on testing host
+# and update the kindest/node: image
 tee -a "${TEST_CLUSTER_DIR}"/Dockerfile <<END
-FROM kindest/node:v1.30.6@sha256:b6d08db72079ba5ae1f4a88a09025c0a904af3b52387643c285442afb05ab994
+FROM kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
 RUN apt-get -y update 
 RUN apt-get -y install wget && apt-get install -y git && apt install -y nano dnsutils
 END

--- a/kind-cluster/run_test
+++ b/kind-cluster/run_test
@@ -72,6 +72,7 @@ tee -a "${TEST_CLUSTER_DIR}"/Dockerfile <<END
 FROM kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
 RUN apt-get -y update 
 RUN apt-get -y install wget && apt-get install -y git && apt install -y nano dnsutils
+RUN groupadd admin && useradd admin -g admin
 END
 
 echo "Building new image using the above Dockerfile. On the local machine: * * *"

--- a/kind-cluster/test-configs/local_cluster_3.x/k8s_client.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x/k8s_client.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:3.23.1
+        image: quay.io/quobyte/quobyte-client:3.24.4
         imagePullPolicy: Always
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2856 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -44,16 +44,23 @@ spec:
             hostPort: 55000
             protocol: TCP
         readinessProbe:
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         livenessProbe:
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         command:
           - /bin/bash
           - -xec
@@ -87,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -102,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/test-configs/local_cluster_3.x/k8s_storage_class.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x/k8s_storage_class.yaml
@@ -34,9 +34,9 @@ parameters:
   # creates quota for the volume if set to true. The size of the Quota
   # is the storage requested in PVC. If false, creates volume without size limit.
   createQuota: "true"
-  user: root
-  group: root
-  accessMode: "777"
+  # user: root
+  # group: root
+  # accessMode: "777"
   
   # spaces are not allowed and requires Quobyte 3.x
   #labels: "encrypted:yes,mediatype:hdd"

--- a/kind-cluster/test-configs/local_cluster_3.x/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x/values.yaml
@@ -5,8 +5,7 @@ quobyte:
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
   # The default below is ready to connect to a Quobyte api 
   # service running on the same Kubernetes cluster
-  apiURL: http://venkat.corp.quobyte.com:2849
-
+  apiURL: http://venkat.corp.quobyte.com:2769
   # Replication for csi controller pod, must be at least one
   # Note that node driver which is responsible for mounting volume cannot be replicated
   csiControllerReplicas: 1
@@ -75,7 +74,7 @@ quobyte:
     # github.com/quobyte/quobyte-csi
     csiImage: "quay.io/quobyte/csi:v2.1.1"
     # github.com/quobyte/pod-killer
-    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.1"
+    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.2"
     # k8s sidecar containers (https://github.com/kubernetes-csi/)
     # Updating k8s...Image might require RBAC files update
     # https://github.com/quobyte/quobyte-csi/tree/master/quobyte-csi-driver/templates/pods/rbac

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys/k8s_client.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys/k8s_client.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:3.21.1
+        image: quay.io/quobyte/quobyte-client:3.24.4
         imagePullPolicy: Always
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2205 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -44,16 +44,23 @@ spec:
             hostPort: 55000
             protocol: TCP
         readinessProbe:
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         livenessProbe:
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         command:
           - /bin/bash
           - -xec
@@ -87,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -102,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys/k8s_quobyte_secret.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys/k8s_quobyte_secret.yaml
@@ -5,5 +5,5 @@ metadata:
 type: "kubernetes.io/quobyte"
 data:
   # base64 encoded values of all_uses_access_key.csv
-  accessKeyId: "TUJuTmdVdkRqZFpTQnlYcE1qQks="
-  accessKeySecret: "OVpCa2duTVNGYTltdCtYSGZ3cE5Td3lHWHJ6MkRKdEZYQkE3TUVtRA=="
+  accessKeyId: "UTRBaGowUHZVYlg1bjNmOGVjdlc="
+  accessKeySecret: "cGFIaEphMjcvMVU3c1ZIbkoyVXErSjhBN1dmSzkvL2FQOTg5dXc0Lw=="

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys/values.yaml
@@ -5,7 +5,7 @@ quobyte:
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
   # The default below is ready to connect to a Quobyte api 
   # service running on the same Kubernetes cluster
-  apiURL: http://venkat.corp.quobyte.com:2198
+  apiURL: http://venkat.corp.quobyte.com:2769
 
   # Replication for csi controller pod, must be at least one
   # Note that node driver which is responsible for mounting volume cannot be replicated
@@ -75,7 +75,7 @@ quobyte:
     # github.com/quobyte/quobyte-csi
     csiImage: "quay.io/quobyte/csi:v2.1.1"
     # github.com/quobyte/pod-killer
-    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.1"
+    podKillerImage: "quay.io/quobyte/pod-killer:v0.2.2"
     # k8s sidecar containers (https://github.com/kubernetes-csi/)
     # Updating k8s...Image might require RBAC files update
     # https://github.com/quobyte/quobyte-csi/tree/master/quobyte-csi-driver/templates/pods/rbac

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_01_quobyte_mount_secret.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_01_quobyte_mount_secret.yaml
@@ -5,5 +5,5 @@ metadata:
 type: "kubernetes.io/quobyte"
 data:
   # base64 encoded values of mount_access_key.csv
-  accessKeyId: "UHJIOUNrUHA4TlYwRVBEbkY3a2E="
-  accessKeySecret: "c0gvWlo5YTQ2VXUrRDl3eWJ0TnBWVllxSjZxQWN1emFLQURQRVE3dg=="
+  accessKeyId: "TXFITTdndlJ4NDF6ZXVUQnA4UkI="
+  accessKeySecret: "V0s4dGFUNUtLa3RZZ3pFRW0xSkE4UkFnTmphRkdVSHNWMXE5RHN1cg=="

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_02_quobyte_api_secret.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_02_quobyte_api_secret.yaml
@@ -5,5 +5,5 @@ metadata:
 type: "kubernetes.io/quobyte"
 data:
   # base64 encoded values of mount_access_key.csv
-  accessKeyId: "WXlLWmp3Z2hlV3EyNTg4U1hNQkI="
-  accessKeySecret: "UEg2V1l1MGFWclpCM1VlKzZrN3NEVzJjOUgxUFI4dW52aEpqWE5ZTg=="
+  accessKeyId: "UHpWNjhHZzM3UkcyTXNrOUM5RXY="
+  accessKeySecret: "UGVDV2ZuOHA3MVFFdXhGVGVSekFoZkVDdmFqSGt3d1dqcnNjdEZtZw=="

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_client.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/k8s_client.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:3.21.1
+        image: quay.io/quobyte/quobyte-client:3.24.4
         imagePullPolicy: Always
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2439 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -44,16 +44,23 @@ spec:
             hostPort: 55000
             protocol: TCP
         readinessProbe:
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         livenessProbe:
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         command:
           - /bin/bash
           - -xec
@@ -87,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -102,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_accesskeys_2/values.yaml
@@ -5,7 +5,7 @@ quobyte:
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
   # The default below is ready to connect to a Quobyte api 
   # service running on the same Kubernetes cluster
-  apiURL: http://venkat.corp.quobyte.com:2432
+  apiURL: http://venkat.corp.quobyte.com:2769
 
   # Replication for csi controller pod, must be at least one
   # Note that node driver which is responsible for mounting volume cannot be replicated

--- a/kind-cluster/test-configs/local_cluster_3.x_shared_volume/k8s_client.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_shared_volume/k8s_client.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:3.21.1
+        image: quay.io/quobyte/quobyte-client:3.24.4
         imagePullPolicy: Always
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2267 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -44,23 +44,30 @@ spec:
             hostPort: 55000
             protocol: TCP
         readinessProbe:
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         livenessProbe:
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         command:
           - /bin/bash
           - -xec
           - |
             ENABLE_ACCESS_CONTEXTS=""
             if [[ ${ENABLE_ACCESS_KEY_MOUNTS} = true ]]; then
-              ENABLE_ACCESS_CONTEXTS="--enable-access-contexts"
+              ENABLE_ACCESS_CONTEXTS="--enable-access-contexts --no-default-permissions"
             fi
             if cut -d" " -f2 /proc/self/mounts | grep -q ${QUOBYTE_MOUNT_POINT}; then
               umount -l ${QUOBYTE_MOUNT_POINT}
@@ -87,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -102,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/test-configs/local_cluster_3.x_shared_volume/k8s_storage_class.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_shared_volume/k8s_storage_class.yaml
@@ -37,9 +37,9 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-namespace: "quobyte"
   # creates quota for the volume if set to true. The size of the Quota
   # is the storage requested in PVC. If false, creates volume without size limit.
-  user: root
-  group: root
-  accessMode: "750"
+  # user: root
+  # group: root
+  # accessMode: "750"
   # spaces are not allowed and requires Quobyte 3.x
   #labels: "encrypted:yes,mediatype:hdd"
 # Set reclaimPolicy: Retain to keep the volume even after PV deletion

--- a/kind-cluster/test-configs/local_cluster_3.x_shared_volume/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_shared_volume/values.yaml
@@ -5,7 +5,7 @@ quobyte:
   version: 3
   # apiURL should be of the form http(s)://<ip or resolvable host>:<port>
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
-  apiURL: "http://venkat.corp.quobyte.com:2260"
+  apiURL: "http://venkat.corp.quobyte.com:2769"
 
   # Replication for csi controller pod, must be at least one
   # Note that node driver which is responsible for mounting volume cannot be replicated

--- a/kind-cluster/test-configs/local_cluster_3.x_snapshots/k8s_client.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_snapshots/k8s_client.yaml
@@ -19,14 +19,14 @@ spec:
     spec:
       containers:
       - name: quobyte-client
-        image: quay.io/quobyte/quobyte-client:3
+        image: quay.io/quobyte/quobyte-client:3.24.4
         imagePullPolicy: Always
         env:
           - name: QUOBYTE_CLIENT_LOG_LEVEL
             value: INFO
           - name: QUOBYTE_REGISTRY
             # Your Quobyte registry endpoint
-            value: venkat.corp.quobyte.com:2927 # Example: hydrogen.quobyte.com:12354
+            value: venkat.corp.quobyte.com:2776 # Example: hydrogen.quobyte.com:12354
           - name: QUOBYTE_MOUNT_POINT
             # Corresponding volume mount must be one directory below this path
             # Example volumeMount is : /home/quobyte and clientMountPoint is /home/quobyte/mounts
@@ -44,16 +44,23 @@ spec:
             hostPort: 55000
             protocol: TCP
         readinessProbe:
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         livenessProbe:
-          initialDelaySeconds: 30
-          timeoutSeconds: 5
-          httpGet:
-            port: 55000
-            path: /
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          exec:
+            command:
+              - /bin/bash
+              - "-c"
+              - |
+                getfattr -n quobyte.statuspage_port ${QUOBYTE_MOUNT_POINT}
         command:
           - /bin/bash
           - -xec
@@ -87,6 +94,12 @@ spec:
           - name: quobyte-mount
             mountPath: /home/quobyte
             mountPropagation: Bidirectional
+          - name: users
+            mountPath: /etc/passwd
+            mountPropagation: HostToContainer
+          - name: groups
+            mountPath: /etc/group
+            mountPropagation: HostToContainer
           - name: minidumps-dir
             mountPath: /tmp/minidumps
         lifecycle:
@@ -102,3 +115,11 @@ spec:
       - name: minidumps-dir
         hostPath:
           path: /var/lib/quobyte/.minidumps
+      - name: users
+        hostPath:
+          path: /etc/passwd
+          type: File
+      - name: groups
+        hostPath:
+          path: /etc/group
+          type: File

--- a/kind-cluster/test-configs/local_cluster_3.x_snapshots/k8s_storage_class.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_snapshots/k8s_storage_class.yaml
@@ -34,9 +34,9 @@ parameters:
   # creates quota for the volume if set to true. The size of the Quota
   # is the storage requested in PVC. If false, creates volume without size limit.
   createQuota: "true"
-  user: root
-  group: root
-  accessMode: "777"
+  # user: root
+  # group: root
+  # accessMode: "777"
   
   # spaces are not allowed and requires Quobyte 3.x
   #labels: "encrypted:yes,mediatype:hdd"

--- a/kind-cluster/test-configs/local_cluster_3.x_snapshots/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_snapshots/values.yaml
@@ -5,7 +5,7 @@ quobyte:
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
   # The default below is ready to connect to a Quobyte api 
   # service running on the same Kubernetes cluster
-  apiURL: http://venkat.corp.quobyte.com:2920
+  apiURL: http://venkat.corp.quobyte.com:2769
 
   # Replication for csi controller pod, must be at least one
   # Note that node driver which is responsible for mounting volume cannot be replicated

--- a/src/driver/controller.go
+++ b/src/driver/controller.go
@@ -33,6 +33,8 @@ const (
 	DefaultSharedVolumeAccessModes = 1777
 	// Permissions for /<shared-volume>/<pvc-volume>
 	// Set sticky bit so that other users cannot delete volume
+	// As of golang version 1.22.5, the sticky bit does not work and only user:group:other permissions work
+	// https://github.com/golang/go/issues/44575
 	DefaultPVCAccessModeInsideSharedVolume = 1700
 	// Metadata from K8S CSI external provisioner
 	pvcNamespaceKey = "csi.storage.k8s.io/pvc/namespace"

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/quobyte/api v1.3.0
+	github.com/quobyte/api v1.4.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/sys v0.29.0
@@ -26,4 +26,4 @@ require (
 )
 
 // Uncomment only during testing with local version of Quobyte API
-//replace github.com/quobyte/api => /home/venkat/go/src/github.com/quobyte/api
+// replace github.com/quobyte/api => /home/venkat/go/api

--- a/src/go.sum
+++ b/src/go.sum
@@ -13,8 +13,8 @@ github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iP
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/quobyte/api v1.3.0 h1:4Qto1m+dgoqSH9o3C8TvwpN+08lmEiOxEBcQOPzmg9s=
-github.com/quobyte/api v1.3.0/go.mod h1:+TJmul6UJXpU0QLE0Rq2lFCYcr7GNyKrVOdMJCnZkY0=
+github.com/quobyte/api v1.4.0 h1:EsqVKoOExrvghk1Y3h+lQ3d9nm6f59tDoAtVIImNP9k=
+github.com/quobyte/api v1.4.0/go.mod h1:+TJmul6UJXpU0QLE0Rq2lFCYcr7GNyKrVOdMJCnZkY0=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=

--- a/usage-example/shared-volume/README.md
+++ b/usage-example/shared-volume/README.md
@@ -54,7 +54,8 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-namespace: "quobyte"
   csi.storage.k8s.io/node-publish-secret-name: "quobyte-admin-credentials"
   csi.storage.k8s.io/node-publish-secret-namespace: "quobyte"
-  # optional user/group - if not provided, user/group is derived from the user credentials
+  # user/group is optional - if not provided, user/group is retrieved from the Quobyte user
+  # associated with the provisioner-secret provided above.
   user: root
   group: root
   # Permissions for PVC directory created inside shared volume (if not provided defaults to 700)

--- a/usage-example/shared-volume/README.md
+++ b/usage-example/shared-volume/README.md
@@ -8,7 +8,8 @@ exclusive Quobyte volume.
 * Requires Quobyte client on Quobyte CSI controller pod (quobyte-csi-controller-....) running host
   with the [mount path](https://github.com/quobyte/quobyte-csi-driver/blob/v1.8.4/csi-driver-templates/values.yaml#L21)
 
-* Shared volume(s) must be accessible on the Quobyte CSI controller node.
+* Shared volume(s) must be accessible on the Quobyte CSI controller node. Suggested permissions on shared volume "1777".
+  Furtehr, the PV permissions via StorageClass should be restricted to user:group (<ug>0).
 
 * For Quobyte 2.x cluster, your Quobyte CSI driver should be
   deployed with `quobyte.sharedVolumesList`. Quobyte CSI driver runs periodic cleanup of these
@@ -40,6 +41,8 @@ parameters:
   # provisions PV as subdirectory of the "shared_volume"
   # Not having "sharedVolumeName" parameter, triggers creation of a new Quobyte volume
   # (with the name same as PV's name) for the dynamic provisioning
+  # If shared volume is created beforehand, permissions should be 1777, so that PVCs can
+  # be accessed by other users.
   sharedVolumeName: "shared_volume"
   # createQuota is not required with shared volumes and ignored if provided.
   # If Storage admin requires Quota for shared volumes, they must set Quota for volume via
@@ -51,8 +54,12 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-namespace: "quobyte"
   csi.storage.k8s.io/node-publish-secret-name: "quobyte-admin-credentials"
   csi.storage.k8s.io/node-publish-secret-namespace: "quobyte"
+  # optional user/group - if not provided, user/group is derived from the user credentials
   user: root
   group: root
+  # Permissions for PVC directory created inside shared volume (if not provided defaults to 700)
+  # Keep other permissions to 0, so that only user[/group] can access this PV inside shared
+  # volume.
   accessMode: "750"
 reclaimPolicy: Delete
 ```


### PR DESCRIPTION
* Use whoAmI api to dertermine user from the authentication context
* Improve shared volume feature (still only Quobyte SUPER_USER can delete shared volume PVs)
* Mount /etc/passwd and /etc/group into Quobyte CSI driver pods. Also, add the same to Quobyte client deployment example definition.
