### PR TITLE
Add node selector

### DIFF
--- a/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
@@ -26,6 +26,10 @@ spec:
         app: quobyte-csi-controller-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
+    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+      nodeSelector:
+        {{ .Values.quobyte.nodeSelector | trim }}
+    {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
 {{- if .Values.quobyte.tolerations }}

--- a/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
@@ -19,6 +19,10 @@ spec:
         app: quobyte-csi-node-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi
     spec:
+    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+      nodeSelector:
+        {{ .Values.quobyte.nodeSelector | trim }}
+    {{- end }}
       priorityClassName: system-node-critical
       serviceAccount: quobyte-csi-node-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
       hostNetwork: true

--- a/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
@@ -21,6 +21,10 @@ spec:
         app: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
+    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+      nodeSelector:
+        {{ .Values.quobyte.nodeSelector | trim }}
+    {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-pod-killer-cache-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
 {{- if .Values.quobyte.tolerations }}

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -63,6 +63,11 @@ quobyte:
   # are not required to be exported as Prometheus metrics.
   enableVolumeMetrics: true
 
+  # Quobyte CSI driver is only deployed on nodes with the specified label.
+  # Empty means all the nodes in the k8s cluster i.e. no node selector will be used.
+  # nodeSelector: "<node-label-name>: '<node-label-value>'"
+  nodeSelector: ""
+
   podKiller:
     # To disable pod killer, uninstall current CSI driver (helm uninstall <chart-name>)
     # set enable: false and install CSI driver again

--- a/kind-cluster/run_test
+++ b/kind-cluster/run_test
@@ -66,10 +66,11 @@ echo ""
 echo ""
 
 # https://github.com/kubernetes-sigs/kind/releases
-# Install the latest kind binary from the releases on testing host
+# Install the latest kind binary (download and add executable
+# to your PATH) from the releases on testing host
 # and update the kindest/node: image
 tee -a "${TEST_CLUSTER_DIR}"/Dockerfile <<END
-FROM kindest/node:v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027
+FROM kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f
 RUN apt-get -y update 
 RUN apt-get -y install wget && apt-get install -y git && apt install -y nano dnsutils
 RUN groupadd admin && useradd admin -g admin

--- a/kind-cluster/run_test
+++ b/kind-cluster/run_test
@@ -132,7 +132,7 @@ fi
 # makes nodes hang in NotReady
 dns_ips="$(kubectl get services -n kube-system | grep 'kube-dns' | awk '{print $3}')"
 if [[ -z "$dns_ips" ]]; then
-  echo "Error: could not retrive kube-dns IP required"
+  echo "Error: could not retrieve required kube-dns IP"
   exit 1
 fi
 if ! [[ "$dns_ips" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then


### PR DESCRIPTION
* Add node selector support to restrict Quobyte CSI Driver pod deployment to a subset of k8s cluster nodes

(Also, upgrades k8s test setup and related minor fixes)