### PR TITLE
Cleanup shared volume with rm command

### DIFF
--- a/csi-driver-templates/k8s-snapshot-controller.yaml
+++ b/csi-driver-templates/k8s-snapshot-controller.yaml
@@ -1,4 +1,4 @@
-# https://github.com/kubernetes-csi/external-snapshotter/blob/v7.0.2/deploy/kubernetes/snapshot-controller
+# https://github.com/kubernetes-csi/external-snapshotter/blob/v8.3.0/deploy/kubernetes/snapshot-controller
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -32,7 +32,7 @@ rules:
     verbs: ["patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update", "patch"]
@@ -83,20 +83,6 @@ rules:
   verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: snapshot-controller-leaderelection
-  namespace: kube-system
-subjects:
-  - kind: ServiceAccount
-    name: snapshot-controller
-roleRef:
-  kind: Role
-  name: snapshot-controller-leaderelection
-  apiGroup: rbac.authorization.k8s.io
-
----
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -125,7 +111,7 @@ spec:
       serviceAccountName: snapshot-controller
       containers:
         - name: snapshot-controller
-          image: registry.k8s.io/sig-storage/snapshot-controller:v6.3.1
+          image: registry.k8s.io/sig-storage/snapshot-controller:v8.2.1
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/csi-driver-templates/k8s-snapshot-crd.yaml
+++ b/csi-driver-templates/k8s-snapshot-crd.yaml
@@ -1,4 +1,4 @@
-# https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v7.0.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+# https://github.com/kubernetes-csi/external-snapshotter/blob/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -6,8 +6,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -36,44 +35,52 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshotClass specifies parameters that a underlying storage
-          system uses when creating a volume snapshot. A specific VolumeSnapshotClass
-          is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
-          are non-namespaced
+        description: |-
+          VolumeSnapshotClass specifies parameters that a underlying storage system uses when
+          creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its
+          name in a VolumeSnapshot object.
+          VolumeSnapshotClasses are non-namespaced
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           deletionPolicy:
-            description: deletionPolicy determines whether a VolumeSnapshotContent
-              created through the VolumeSnapshotClass should be deleted when its bound
-              VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
-              "Retain" means that the VolumeSnapshotContent and its physical snapshot
-              on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
-              and its physical snapshot on underlying storage system are deleted.
+            description: |-
+              deletionPolicy determines whether a VolumeSnapshotContent created through
+              the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
               Required.
             enum:
             - Delete
             - Retain
             type: string
           driver:
-            description: driver is the name of the storage driver that handles this
-              VolumeSnapshotClass. Required.
+            description: |-
+              driver is the name of the storage driver that handles this VolumeSnapshotClass.
+              Required.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           parameters:
             additionalProperties:
               type: string
-            description: parameters is a key-value map with storage driver specific
-              parameters for creating snapshots. These values are opaque to Kubernetes.
+            description: |-
+              parameters is a key-value map with storage driver specific parameters for creating snapshots.
+              These values are opaque to Kubernetes.
             type: object
         required:
         - deletionPolicy
@@ -137,15 +144,14 @@ status:
   conditions: []
   storedVersions: []
 
-# https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v7.0.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+# https://github.com/kubernetes-csi/external-snapshotter/blob/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/955"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -188,7 +194,8 @@ spec:
       jsonPath: .spec.volumeSnapshotRef.name
       name: VolumeSnapshot
       type: string
-    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent
+        object is bound.
       jsonPath: .spec.volumeSnapshotRef.namespace
       name: VolumeSnapshotNamespace
       type: string
@@ -198,154 +205,206 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshotContent represents the actual "on-disk" snapshot
-          object in the underlying storage system
+        description: |-
+          VolumeSnapshotContent represents the actual "on-disk" snapshot object in the
+          underlying storage system
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: spec defines properties of a VolumeSnapshotContent created
-              by the underlying storage system. Required.
+            description: |-
+              spec defines properties of a VolumeSnapshotContent created by the underlying storage system.
+              Required.
             properties:
               deletionPolicy:
-                description: deletionPolicy determines whether this VolumeSnapshotContent
-                  and its physical snapshot on the underlying storage system should
-                  be deleted when its bound VolumeSnapshot is deleted. Supported values
-                  are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
-                  and its physical snapshot on underlying storage system are kept.
-                  "Delete" means that the VolumeSnapshotContent and its physical snapshot
-                  on underlying storage system are deleted. For dynamically provisioned
-                  snapshots, this field will automatically be filled in by the CSI
-                  snapshotter sidecar with the "DeletionPolicy" field defined in the
-                  corresponding VolumeSnapshotClass. For pre-existing snapshots, users
-                  MUST specify this field when creating the VolumeSnapshotContent
-                  object. Required.
+                description: |-
+                  deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on
+                  the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted.
+                  For dynamically provisioned snapshots, this field will automatically be filled in by the
+                  CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding
+                  VolumeSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                   VolumeSnapshotContent object.
+                  Required.
                 enum:
                 - Delete
                 - Retain
                 type: string
               driver:
-                description: driver is the name of the CSI driver used to create the
-                  physical snapshot on the underlying storage system. This MUST be
-                  the same as the name returned by the CSI GetPluginName() call for
-                  that driver. Required.
+                description: |-
+                  driver is the name of the CSI driver used to create the physical snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
                 type: string
               source:
-                description: source specifies whether the snapshot is (or should be)
-                  dynamically provisioned or already exists, and just requires a Kubernetes
-                  object representation. This field is immutable after creation. Required.
+                description: |-
+                  source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   snapshotHandle:
-                    description: snapshotHandle specifies the CSI "snapshot_id" of
-                      a pre-existing snapshot on the underlying storage system for
-                      which a Kubernetes object representation was (or should be)
-                      created. This field is immutable.
-                    type: string
-                  volumeHandle:
-                    description: volumeHandle specifies the CSI "volume_id" of the
-                      volume from which a snapshot should be dynamically taken from.
+                    description: |-
+                      snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on
+                      the underlying storage system for which a Kubernetes object representation
+                      was (or should be) created.
                       This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: snapshotHandle is immutable
+                      rule: self == oldSelf
+                  volumeHandle:
+                    description: |-
+                      volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot
+                      should be dynamically taken from.
+                      This field is immutable.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: volumeHandle is immutable
+                      rule: self == oldSelf
                 type: object
-                oneOf:
-                - required: ["snapshotHandle"]
-                - required: ["volumeHandle"]
+                x-kubernetes-validations:
+                - message: volumeHandle is required once set
+                  rule: '!has(oldSelf.volumeHandle) || has(self.volumeHandle)'
+                - message: snapshotHandle is required once set
+                  rule: '!has(oldSelf.snapshotHandle) || has(self.snapshotHandle)'
+                - message: exactly one of volumeHandle and snapshotHandle must be
+                    set
+                  rule: (has(self.volumeHandle) && !has(self.snapshotHandle)) || (!has(self.volumeHandle)
+                    && has(self.snapshotHandle))
               sourceVolumeMode:
-                description: SourceVolumeMode is the mode of the volume whose snapshot
-                  is taken. Can be either “Filesystem” or “Block”. If not specified,
-                  it indicates the source volume's mode is unknown. This field is
-                  immutable. This field is an alpha field.
+                description: |-
+                  SourceVolumeMode is the mode of the volume whose snapshot is taken.
+                  Can be either “Filesystem” or “Block”.
+                  If not specified, it indicates the source volume's mode is unknown.
+                  This field is immutable.
+                  This field is an alpha field.
                 type: string
+                x-kubernetes-validations:
+                - message: sourceVolumeMode is immutable
+                  rule: self == oldSelf
               volumeSnapshotClassName:
-                description: name of the VolumeSnapshotClass from which this snapshot
-                  was (or will be) created. Note that after provisioning, the VolumeSnapshotClass
-                  may be deleted or recreated with different set of values, and as
-                  such, should not be referenced post-snapshot creation.
+                description: |-
+                  name of the VolumeSnapshotClass from which this snapshot was (or will be)
+                  created.
+                  Note that after provisioning, the VolumeSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
                 type: string
               volumeSnapshotRef:
-                description: volumeSnapshotRef specifies the VolumeSnapshot object
-                  to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
-                  field must reference to this VolumeSnapshotContent's name for the
-                  bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
-                  object, name and namespace of the VolumeSnapshot object MUST be
-                  provided for binding to happen. This field is immutable after creation.
+                description: |-
+                  volumeSnapshotRef specifies the VolumeSnapshot object to which this
+                  VolumeSnapshotContent object is bound.
+                  VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to
+                  this VolumeSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeSnapshotContent object, name and namespace of the
+                  VolumeSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
                   Required.
                 properties:
                   apiVersion:
                     description: API version of the referent.
                     type: string
                   fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                     type: string
                   resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                     type: string
                   uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both spec.volumeSnapshotRef.name and spec.volumeSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
             required:
             - deletionPolicy
             - driver
             - source
             - volumeSnapshotRef
             type: object
+            x-kubernetes-validations:
+            - message: sourceVolumeMode is required once set
+              rule: '!has(oldSelf.sourceVolumeMode) || has(self.sourceVolumeMode)'
           status:
             description: status represents the current information of a snapshot.
             properties:
               creationTime:
-                description: creationTime is the timestamp when the point-in-time
-                  snapshot is taken by the underlying storage system. In dynamic snapshot
-                  creation case, this field will be filled in by the CSI snapshotter
-                  sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
-                  gRPC call. For a pre-existing snapshot, this field will be filled
-                  with the "creation_time" value returned from the CSI "ListSnapshots"
-                  gRPC call if the driver supports it. If not specified, it indicates
-                  the creation time is unknown. The format of this field is a Unix
-                  nanoseconds time encoded as an int64. On Unix, the command `date
-                  +%s%N` returns the current time in nanoseconds since 1970-01-01
-                  00:00:00 UTC.
+                description: |-
+                  creationTime is the timestamp when the point-in-time snapshot is taken
+                  by the underlying storage system.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "creation_time" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "creation_time"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  If not specified, it indicates the creation time is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                  since 1970-01-01 00:00:00 UTC.
                 format: int64
                 type: integer
               error:
-                description: error is the last observed error during snapshot creation,
-                  if any. Upon success after retry, this error field will be cleared.
+                description: |-
+                  error is the last observed error during snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
@@ -353,38 +412,40 @@ spec:
                     type: string
                 type: object
               readyToUse:
-                description: readyToUse indicates if a snapshot is ready to be used
-                  to restore a volume. In dynamic snapshot creation case, this field
-                  will be filled in by the CSI snapshotter sidecar with the "ready_to_use"
-                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "ready_to_use" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it, otherwise, this field will be set to "True". If not specified,
-                  it means the readiness of a snapshot is unknown.
+                description: |-
+                  readyToUse indicates if a snapshot is ready to be used to restore a volume.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "ready_to_use" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                  otherwise, this field will be set to "True".
+                  If not specified, it means the readiness of a snapshot is unknown.
                 type: boolean
               restoreSize:
-                description: restoreSize represents the complete size of the snapshot
-                  in bytes. In dynamic snapshot creation case, this field will be
-                  filled in by the CSI snapshotter sidecar with the "size_bytes" value
-                  returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "size_bytes" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it. When restoring a volume from this snapshot, the size of the
-                  volume MUST NOT be smaller than the restoreSize if it is specified,
-                  otherwise the restoration will fail. If not specified, it indicates
-                  that the size is unknown.
+                description: |-
+                  restoreSize represents the complete size of the snapshot in bytes.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  CSI snapshotter sidecar with the "size_bytes" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  When restoring a volume from this snapshot, the size of the volume MUST NOT
+                  be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                  If not specified, it indicates that the size is unknown.
                 format: int64
                 minimum: 0
                 type: integer
               snapshotHandle:
-                description: snapshotHandle is the CSI "snapshot_id" of a snapshot
-                  on the underlying storage system. If not specified, it indicates
-                  that dynamic snapshot creation has either failed or it is still
-                  in progress.
+                description: |-
+                  snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system.
+                  If not specified, it indicates that dynamic snapshot creation has either failed
+                  or it is still in progress.
                 type: string
               volumeGroupSnapshotHandle:
-                description: VolumeGroupSnapshotHandle is the CSI "group_snapshot_id"
-                  of a group snapshot on the underlying storage system.
+                description: |-
+                  VolumeGroupSnapshotHandle is the CSI "group_snapshot_id" of a group snapshot
+                  on the underlying storage system.
                 type: string
             type: object
         required:
@@ -542,16 +603,14 @@ status:
   conditions: []
   storedVersions: []
 
-# https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/v7.0.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
----
+# https://github.com/kubernetes-csi/external-snapshotter/blob/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
-    controller-gen.kubebuilder.io/version: v0.12.0
-  creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
   group: snapshot.storage.k8s.io
@@ -607,105 +666,140 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: VolumeSnapshot is a user's request for either creating a point-in-time
+        description: |-
+          VolumeSnapshot is a user's request for either creating a point-in-time
           snapshot of a persistent volume, or binding to a pre-existing snapshot.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: 'spec defines the desired characteristics of a snapshot requested
-              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
-              Required.'
+            description: |-
+              spec defines the desired characteristics of a snapshot requested by a user.
+              More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+              Required.
             properties:
               source:
-                description: source specifies where a snapshot will be created from.
-                  This field is immutable after creation. Required.
+                description: |-
+                  source specifies where a snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
                 properties:
                   persistentVolumeClaimName:
-                    description: persistentVolumeClaimName specifies the name of the
-                      PersistentVolumeClaim object representing the volume from which
-                      a snapshot should be created. This PVC is assumed to be in the
-                      same namespace as the VolumeSnapshot object. This field should
-                      be set if the snapshot does not exists, and needs to be created.
+                    description: |-
+                      persistentVolumeClaimName specifies the name of the PersistentVolumeClaim
+                      object representing the volume from which a snapshot should be created.
+                      This PVC is assumed to be in the same namespace as the VolumeSnapshot
+                      object.
+                      This field should be set if the snapshot does not exists, and needs to be
+                      created.
                       This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: persistentVolumeClaimName is immutable
+                      rule: self == oldSelf
                   volumeSnapshotContentName:
-                    description: volumeSnapshotContentName specifies the name of a
-                      pre-existing VolumeSnapshotContent object representing an existing
-                      volume snapshot. This field should be set if the snapshot already
-                      exists and only needs a representation in Kubernetes. This field
-                      is immutable.
+                    description: |-
+                      volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent
+                      object representing an existing volume snapshot.
+                      This field should be set if the snapshot already exists and only needs a representation in Kubernetes.
+                      This field is immutable.
                     type: string
+                    x-kubernetes-validations:
+                    - message: volumeSnapshotContentName is immutable
+                      rule: self == oldSelf
                 type: object
-                oneOf:
-                - required: ["persistentVolumeClaimName"]
-                - required: ["volumeSnapshotContentName"]
+                x-kubernetes-validations:
+                - message: persistentVolumeClaimName is required once set
+                  rule: '!has(oldSelf.persistentVolumeClaimName) || has(self.persistentVolumeClaimName)'
+                - message: volumeSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeSnapshotContentName) || has(self.volumeSnapshotContentName)'
+                - message: exactly one of volumeSnapshotContentName and persistentVolumeClaimName
+                    must be set
+                  rule: (has(self.volumeSnapshotContentName) && !has(self.persistentVolumeClaimName))
+                    || (!has(self.volumeSnapshotContentName) && has(self.persistentVolumeClaimName))
               volumeSnapshotClassName:
-                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
-                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
-                  left nil to indicate that the default SnapshotClass should be used.
-                  A given cluster may have multiple default Volume SnapshotClasses:
-                  one default per CSI Driver. If a VolumeSnapshot does not specify
-                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
-                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
-                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
-                  exist for a given CSI Driver and more than one have been marked
-                  as default, CreateSnapshot will fail and generate an event. Empty
-                  string is not allowed for this field.'
+                description: |-
+                  VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                  requested by the VolumeSnapshot.
+                  VolumeSnapshotClassName may be left nil to indicate that the default
+                  SnapshotClass should be used.
+                  A given cluster may have multiple default Volume SnapshotClasses: one
+                  default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass,
+                  VolumeSnapshotSource will be checked to figure out what the associated
+                  CSI Driver is, and the default VolumeSnapshotClass associated with that
+                  CSI Driver will be used. If more than one VolumeSnapshotClass exist for
+                  a given CSI Driver and more than one have been marked as default,
+                  CreateSnapshot will fail and generate an event.
+                  Empty string is not allowed for this field.
                 type: string
+                x-kubernetes-validations:
+                - message: volumeSnapshotClassName must not be the empty string when
+                    set
+                  rule: size(self) > 0
             required:
             - source
             type: object
           status:
-            description: status represents the current information of a snapshot.
-              Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent
-              objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent
-              point at each other) before using this object.
+            description: |-
+              status represents the current information of a snapshot.
+              Consumers must verify binding between VolumeSnapshot and
+              VolumeSnapshotContent objects is successful (by validating that both
+              VolumeSnapshot and VolumeSnapshotContent point at each other) before
+              using this object.
             properties:
               boundVolumeSnapshotContentName:
-                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
-                  object to which this VolumeSnapshot object intends to bind to. If
-                  not specified, it indicates that the VolumeSnapshot object has not
-                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
-                  To avoid possible security issues, consumers must verify binding
-                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
-                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
-                  point at each other) before using this object.'
+                description: |-
+                  boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                  object to which this VolumeSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeSnapshot object has not been
+                  successfully bound to a VolumeSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that
+                  both VolumeSnapshot and VolumeSnapshotContent point at each other) before using
+                  this object.
                 type: string
               creationTime:
-                description: creationTime is the timestamp when the point-in-time
-                  snapshot is taken by the underlying storage system. In dynamic snapshot
-                  creation case, this field will be filled in by the snapshot controller
-                  with the "creation_time" value returned from CSI "CreateSnapshot"
-                  gRPC call. For a pre-existing snapshot, this field will be filled
-                  with the "creation_time" value returned from the CSI "ListSnapshots"
-                  gRPC call if the driver supports it. If not specified, it may indicate
-                  that the creation time of the snapshot is unknown.
+                description: |-
+                  creationTime is the timestamp when the point-in-time snapshot is taken
+                  by the underlying storage system.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "creation_time" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "creation_time"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  If not specified, it may indicate that the creation time of the snapshot is unknown.
                 format: date-time
                 type: string
               error:
-                description: error is the last observed error during snapshot creation,
-                  if any. This field could be helpful to upper level controllers(i.e.,
-                  application controller) to decide whether they should continue on
-                  waiting for the snapshot to be created based on the type of error
-                  reported. The snapshot controller will keep retrying when an error
-                  occurs during the snapshot creation. Upon success, this error field
-                  will be cleared.
+                description: |-
+                  error is the last observed error during snapshot creation, if any.
+                  This field could be helpful to upper level controllers(i.e., application controller)
+                  to decide whether they should continue on waiting for the snapshot to be created
+                  based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  snapshot creation. Upon success, this error field will be cleared.
                 properties:
                   message:
-                    description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
                     type: string
                   time:
                     description: time is the timestamp when the error was encountered.
@@ -713,32 +807,35 @@ spec:
                     type: string
                 type: object
               readyToUse:
-                description: readyToUse indicates if the snapshot is ready to be used
-                  to restore a volume. In dynamic snapshot creation case, this field
-                  will be filled in by the snapshot controller with the "ready_to_use"
-                  value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
-                  snapshot, this field will be filled with the "ready_to_use" value
-                  returned from the CSI "ListSnapshots" gRPC call if the driver supports
-                  it, otherwise, this field will be set to "True". If not specified,
-                  it means the readiness of a snapshot is unknown.
+                description: |-
+                  readyToUse indicates if the snapshot is ready to be used to restore a volume.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "ready_to_use" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "ready_to_use"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it,
+                  otherwise, this field will be set to "True".
+                  If not specified, it means the readiness of a snapshot is unknown.
                 type: boolean
               restoreSize:
                 type: string
-                description: restoreSize represents the minimum size of volume required
-                  to create a volume from this snapshot. In dynamic snapshot creation
-                  case, this field will be filled in by the snapshot controller with
-                  the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call.
-                  For a pre-existing snapshot, this field will be filled with the
-                  "size_bytes" value returned from the CSI "ListSnapshots" gRPC call
-                  if the driver supports it. When restoring a volume from this snapshot,
-                  the size of the volume MUST NOT be smaller than the restoreSize
-                  if it is specified, otherwise the restoration will fail. If not
-                  specified, it indicates that the size is unknown.
+                description: |-
+                  restoreSize represents the minimum size of volume required to create a volume
+                  from this snapshot.
+                  In dynamic snapshot creation case, this field will be filled in by the
+                  snapshot controller with the "size_bytes" value returned from CSI
+                  "CreateSnapshot" gRPC call.
+                  For a pre-existing snapshot, this field will be filled with the "size_bytes"
+                  value returned from the CSI "ListSnapshots" gRPC call if the driver supports it.
+                  When restoring a volume from this snapshot, the size of the volume MUST NOT
+                  be smaller than the restoreSize if it is specified, otherwise the restoration will fail.
+                  If not specified, it indicates that the size is unknown.
                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                 x-kubernetes-int-or-string: true
               volumeGroupSnapshotName:
-                description: VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot
-                  of which this VolumeSnapshot is a part of.
+                description: |-
+                  VolumeGroupSnapshotName is the name of the VolumeGroupSnapshot of which this
+                  VolumeSnapshot is a part of.
                 type: string
             type: object
         required:

--- a/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_controller_pod.tpl
@@ -26,9 +26,9 @@ spec:
         app: quobyte-csi-controller-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
-    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+    {{- if default "" .Values.quobyte.csiDriverNodeSelector | trim }}
       nodeSelector:
-        {{ .Values.quobyte.nodeSelector | trim }}
+        {{ .Values.quobyte.csiDriverNodeSelector | trim }}
     {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}

--- a/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_node_driver_pod.tpl
@@ -19,9 +19,9 @@ spec:
         app: quobyte-csi-node-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi
     spec:
-    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+    {{- if default "" .Values.quobyte.csiDriverNodeSelector | trim }}
       nodeSelector:
-        {{ .Values.quobyte.nodeSelector | trim }}
+        {{ .Values.quobyte.csiDriverNodeSelector | trim }}
     {{- end }}
       priorityClassName: system-node-critical
       serviceAccount: quobyte-csi-node-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}

--- a/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
+++ b/csi-driver-templates/templates/pods/_quobyte_csi_pod_killer_cache.tpl
@@ -21,9 +21,9 @@ spec:
         app: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
         role: quobyte-csi-pod-killer-cache-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
     spec:
-    {{- if default "" .Values.quobyte.nodeSelector | trim }}
+    {{- if default "" .Values.quobyte.podKillerCacheNodeSelector | trim }}
       nodeSelector:
-        {{ .Values.quobyte.nodeSelector | trim }}
+        {{ .Values.quobyte.podKillerCacheNodeSelector | trim }}
     {{- end }}
       priorityClassName: system-cluster-critical
       serviceAccount: quobyte-csi-pod-killer-cache-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}

--- a/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
+++ b/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
@@ -24,7 +24,7 @@
     - "--quobyte_version={{ .Values.quobyte.version }}"
     - "--immediate_erase={{ .Values.quobyte.immediateErase }}"
     - "--use_k8s_namespace_as_tenant={{ .Values.quobyte.useK8SNamespaceAsTenant }}"
-    - "--shared_volumes_list={{ .Values.quobyte.sharedVolumesList }}"
+    - "--shared_volumes_list={{ join "," .Values.quobyte.sharedVolumesList }}"
     - "--use_delete_files_task={{ .Values.quobyte.useDeleteFilesTaskForSharedVolumeCleanup }}"
     - "--role=controller"
   env:

--- a/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
+++ b/csi-driver-templates/templates/pods/containers/_quobyte_csi_controller_container.tpl
@@ -25,6 +25,7 @@
     - "--immediate_erase={{ .Values.quobyte.immediateErase }}"
     - "--use_k8s_namespace_as_tenant={{ .Values.quobyte.useK8SNamespaceAsTenant }}"
     - "--shared_volumes_list={{ .Values.quobyte.sharedVolumesList }}"
+    - "--use_delete_files_task={{ .Values.quobyte.useDeleteFilesTaskForSharedVolumeCleanup }}"
     - "--role=controller"
   env:
     - name: NODE_ID

--- a/csi-driver-templates/templates/pods/rbac/_sidecar_snapshotter_rbac.tpl
+++ b/csi-driver-templates/templates/pods/rbac/_sidecar_snapshotter_rbac.tpl
@@ -43,6 +43,35 @@ roleRef:
   kind: ClusterRole
   name: external-snapshotter-runner-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
   apiGroup: rbac.authorization.k8s.io
+
 ---
+{{- if gt (.Values.quobyte.csiControllerReplicas | toString | atoi) 1 }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- end }}
+
+---
+{{- if gt (.Values.quobyte.csiControllerReplicas | toString | atoi) 1 }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: quobyte-csi-controller-sa-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: external-snapshotter-leaderelection-{{ .Values.quobyte.csiProvisionerName | replace "." "-"  }}
+  apiGroup: rbac.authorization.k8s.io
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -372,7 +372,7 @@ should render when resource limits are provided:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
-                - --use_delete_files_task=false
+                - --use_delete_files_task=true
                 - --role=controller
               env:
                 - name: NODE_ID
@@ -1031,7 +1031,7 @@ should render when tolerations are provided:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
-                - --use_delete_files_task=false
+                - --use_delete_files_task=true
                 - --role=controller
               env:
                 - name: NODE_ID
@@ -1682,7 +1682,7 @@ should render with default values:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
-                - --use_delete_files_task=false
+                - --use_delete_files_task=true
                 - --role=controller
               env:
                 - name: NODE_ID

--- a/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -372,6 +372,7 @@ should render when resource limits are provided:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
+                - --use_delete_files_task=false
                 - --role=controller
               env:
                 - name: NODE_ID
@@ -1030,6 +1031,7 @@ should render when tolerations are provided:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
+                - --use_delete_files_task=false
                 - --role=controller
               env:
                 - name: NODE_ID
@@ -1680,6 +1682,7 @@ should render with default values:
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
+                - --use_delete_files_task=false
                 - --role=controller
               env:
                 - name: NODE_ID

--- a/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
+++ b/csi-driver-templates/tests/__snapshot__/csi_driver_test.yaml.snap
@@ -302,7 +302,7 @@ should render when resource limits are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+              image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
               imagePullPolicy: IfNotPresent
               name: csi-provisioner
               resources:
@@ -318,7 +318,7 @@ should render when resource limits are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-resizer:v1.8.1
+              image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
               imagePullPolicy: IfNotPresent
               name: csi-resizer
               resources:
@@ -334,7 +334,7 @@ should render when resource limits are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+              image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
               imagePullPolicy: IfNotPresent
               name: csi-attacher
               resources:
@@ -350,7 +350,7 @@ should render when resource limits are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2
+              image: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
               imagePullPolicy: IfNotPresent
               name: csi-snapshotter
               resources:
@@ -368,7 +368,7 @@ should render when resource limits are provided:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
@@ -514,7 +514,7 @@ should render when resource limits are provided:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -541,7 +541,7 @@ should render when resource limits are provided:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --enable_volume_metrics=true
@@ -988,7 +988,7 @@ should render when tolerations are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+              image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
               imagePullPolicy: IfNotPresent
               name: csi-provisioner
               volumeMounts:
@@ -1000,7 +1000,7 @@ should render when tolerations are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-resizer:v1.8.1
+              image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
               imagePullPolicy: IfNotPresent
               name: csi-resizer
               volumeMounts:
@@ -1012,7 +1012,7 @@ should render when tolerations are provided:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+              image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
               imagePullPolicy: IfNotPresent
               name: csi-attacher
               volumeMounts:
@@ -1026,7 +1026,7 @@ should render when tolerations are provided:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
@@ -1172,7 +1172,7 @@ should render when tolerations are provided:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1195,7 +1195,7 @@ should render when tolerations are provided:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --enable_volume_metrics=true
@@ -1638,7 +1638,7 @@ should render with default values:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-provisioner:v4.0.1
+              image: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
               imagePullPolicy: IfNotPresent
               name: csi-provisioner
               volumeMounts:
@@ -1650,7 +1650,7 @@ should render with default values:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-resizer:v1.8.1
+              image: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
               imagePullPolicy: IfNotPresent
               name: csi-resizer
               volumeMounts:
@@ -1662,7 +1662,7 @@ should render with default values:
               env:
                 - name: ADDRESS
                   value: /var/lib/csi/sockets/pluginproxy/csi.sock
-              image: registry.k8s.io/sig-storage/csi-attacher:v4.5.1
+              image: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
               imagePullPolicy: IfNotPresent
               name: csi-attacher
               volumeMounts:
@@ -1676,7 +1676,7 @@ should render with default values:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --shared_volumes_list=
@@ -1818,7 +1818,7 @@ should render with default values:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
-              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
+              image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -1841,7 +1841,7 @@ should render with default values:
                 - --driver_name=csi.quobyte.com
                 - --driver_version=v2.1.6
                 - --enable_access_key_mounts=false
-                - --quobyte_version=3
+                - --quobyte_version=4
                 - --immediate_erase=false
                 - --use_k8s_namespace_as_tenant=false
                 - --enable_volume_metrics=true

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -62,15 +62,10 @@ quobyte:
   # to be used as shared volumes (StorageClass.parameters.sharedVolumeName). However,
   # driver does not cleanup volumes not mentioned here i.e. does not delete PVCs
   # created inside the shared volumes that are not configured here.
-  # Example, sharedVolumesList: "sharedVolume1,mySharedVolume,...,sharedVolumeN"
-  # Name or UUID of the shared volume (UUIDs are preferred to avoid name collisions)
-  sharedVolumesList: ""
-  # If you are creating PVCs at a rapid rate with reclaimPolicy: Delete,
-  # that leads to too many DELETE_FILES_IN_VOLUMES against the same Quobyte volume.
-  # In such setups set this flag to false, Quobyte CSI Driver removes the PVC via
-  # mount point rm -rf
-  useDeleteFilesTaskForSharedVolumeCleanup: false
-
+  sharedVolumesList:
+    # - <volumeUUID1>
+    # - <volumeUUID2>
+    # - <volumeUUIDN>
 
   # Set to 'false' if PVC/volume metrics (used/available/total bytes and inodes)
   # are not required to be exported as Prometheus metrics.
@@ -79,9 +74,12 @@ quobyte:
   # Quobyte CSI driver is only deployed on nodes with the specified label.
   # Empty means all the nodes in the k8s cluster i.e. no node selector will be used.
   # nodeSelector: "<node-label-name>: '<node-label-value>'"
-  podKillerCacheNodeSelector: ""  # for pod killer cache pod
-  csiDriverNodeSelector: "" # all other CSI driver pods
-
+  # Example: csiDriverNodeSelector: "quobyteCsiDriverNode: 'true'"
+  csiDriverNodeSelector: ""
+  # Pod killer cache node selector - leaving it empty creates pod killer cache pod
+  # on any of the k8s node
+  # Example: podKillerCacheNodeSelector: "quobytePodCacheNode: 'true'"
+  podKillerCacheNodeSelector: ""
   podKiller:
     # To disable pod killer, uninstall current CSI driver (helm uninstall <chart-name>)
     # set enable: false and install CSI driver again

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -51,13 +51,26 @@ quobyte:
   # Set to true to schedule erase volume task immediately (supported by Quobyte 3.x)
   immediateErase: false
 
-  # Required only for Quobyte 2.x
-  # Specify list of shared volumes. Quobyte CSI driver allows volumes not listed here
-  # to be used as shared volumes (StorageClass.parameters.sharedVolumeName), however,
-  # driver does not cleanup volumes not mentioned here.
+  # If you are creating PVCs at a rapid rate with reclaimPolicy: Delete,
+  # that leads to too many DELETE_FILES_IN_VOLUMES against the same Quobyte volume.
+  # In such setups set this flag to false, Quobyte CSI Driver removes the PVC using
+  # rm -rf via mount point (only few rm -rf run at a time)
+  useDeleteFilesTaskForSharedVolumeCleanup: true
+
+  # Specify list of shared volume UUIDs if useDeleteFilesTaskForSharedVolumeCleanup is set to false.
+  # Quobyte CSI driver allows volumes not listed here
+  # to be used as shared volumes (StorageClass.parameters.sharedVolumeName). However,
+  # driver does not cleanup volumes not mentioned here i.e. does not delete PVCs
+  # created inside the shared volumes that are not configured here.
   # Example, sharedVolumesList: "sharedVolume1,mySharedVolume,...,sharedVolumeN"
   # Name or UUID of the shared volume (UUIDs are preferred to avoid name collisions)
   sharedVolumesList: ""
+  # If you are creating PVCs at a rapid rate with reclaimPolicy: Delete,
+  # that leads to too many DELETE_FILES_IN_VOLUMES against the same Quobyte volume.
+  # In such setups set this flag to false, Quobyte CSI Driver removes the PVC via
+  # mount point rm -rf
+  useDeleteFilesTaskForSharedVolumeCleanup: false
+
 
   # Set to 'false' if PVC/volume metrics (used/available/total bytes and inodes)
   # are not required to be exported as Prometheus metrics.

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -97,13 +97,13 @@ quobyte:
     # k8s sidecar containers (https://github.com/kubernetes-csi/)
     # Updating k8s...Image might require RBAC files update
     # https://github.com/quobyte/quobyte-csi/tree/master/quobyte-csi-driver/templates/pods/rbac
-    k8sProvisionerImage: "registry.k8s.io/sig-storage/csi-provisioner:v4.0.1"
-    k8sResizerImage: "registry.k8s.io/sig-storage/csi-resizer:v1.8.1"
-    k8sNodeRegistrarImage: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1"
-    k8sAttacherImage: "registry.k8s.io/sig-storage/csi-attacher:v4.5.1"
+    k8sProvisionerImage: "registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"
+    k8sResizerImage: "registry.k8s.io/sig-storage/csi-resizer:v1.14.0"
+    k8sNodeRegistrarImage: "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0"
+    k8sAttacherImage: "registry.k8s.io/sig-storage/csi-attacher:v4.9.0"
     # when updating image for snapshotter, update snaptshotter setup CRD with
     # instructions in README (CRD should be pulled from matched release).
     # Additionally, ./quobyte-csi-driver/k8s-snapshot-controller.yaml
     # (see this file for source link) should be updated with appropriate version
     # files (Do NOT forget updating namespace to kube-system)
-    k8sSnapshotterImage: "registry.k8s.io/sig-storage/csi-snapshotter:v7.0.2"
+    k8sSnapshotterImage: "registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0"

--- a/csi-driver-templates/values.yaml
+++ b/csi-driver-templates/values.yaml
@@ -1,6 +1,6 @@
 quobyte:
-  # Quobyte cluster version (valid values - 2 for Quobyte 2.x/3 for Quobyte 3.x)
-  version: 3
+  # Quobyte cluster version (valid values - 2 for Quobyte 2.x/3 for Quobyte 3.x/4 for 4.x)
+  version: 4
   # apiURL should be of the form http(s)://<ip or resolvable host>:<port>
   # Example Quobyte API: http://hydrogen.quobyte.com:26801
   # The default below is ready to connect to a Quobyte api 
@@ -66,7 +66,8 @@ quobyte:
   # Quobyte CSI driver is only deployed on nodes with the specified label.
   # Empty means all the nodes in the k8s cluster i.e. no node selector will be used.
   # nodeSelector: "<node-label-name>: '<node-label-value>'"
-  nodeSelector: ""
+  podKillerCacheNodeSelector: ""  # for pod killer cache pod
+  csiDriverNodeSelector: "" # all other CSI driver pods
 
   podKiller:
     # To disable pod killer, uninstall current CSI driver (helm uninstall <chart-name>)

--- a/kind-cluster/README.md
+++ b/kind-cluster/README.md
@@ -50,7 +50,7 @@ The aim of these set of scripts is to enable CSI e2e test runs against internal 
     or
 
     You can run with `TEST_CASE_DIR` that contains only CSI driver values.yaml to deploy the driver
-    (note that some defined values such as CSI image/pod killer images are overriden)
+    (note that some defined values such as CSI image/pod killer images are overridden)
 
 ## Cleanup
 

--- a/kind-cluster/test-configs/local_cluster_3.x_shared_volume/values.yaml
+++ b/kind-cluster/test-configs/local_cluster_3.x_shared_volume/values.yaml
@@ -26,7 +26,23 @@ quobyte:
   # Should be a valid DNS name. Do not change this between upgrades, otherwise
   # requires manual delete of Pods, PVCs, PVs and backing volumes.
   # StorageClass.provisioner must match the value configured here. 
-  csiProvisionerName: csi.quobyte.com 
+  csiProvisionerName: csi.quobyte.com
+
+    # If you are creating PVCs at a rapid rate with reclaimPolicy: Delete,
+  # that leads to too many DELETE_FILES_IN_VOLUMES against the same Quobyte volume.
+  # In such setups set this flag to false, Quobyte CSI Driver removes the PVC using
+  # rm -rf via mount point (only few rm -rf run at a time)
+  # useDeleteFilesTaskForSharedVolumeCleanup: true
+
+  # Specify list of shared volume UUIDs if useDeleteFilesTaskForSharedVolumeCleanup is set to false.
+  # Quobyte CSI driver allows volumes not listed here
+  # to be used as shared volumes (StorageClass.parameters.sharedVolumeName). However,
+  # driver does not cleanup volumes not mentioned here i.e. does not delete PVCs
+  # created inside the shared volumes that are not configured here.
+  sharedVolumesList:
+    - "e4413bc1-7adf-4ad9-b3de-4efc311298fa"
+    # - <volumeUUID2>
+    # - <volumeUUIDN>
   
   # When set to true, uses PVC.namespace as Quobyte tenant.
   # This does not create tenants automatically, your storage system must

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -61,8 +61,8 @@ func main() {
 	// Quobyte CSI Driver pods.
 	// We would also need to get the logs of attacher and provisioner pods additionally.
 
-	if *quobyteVersion != 2 && *quobyteVersion != 3 {
-		klog.Errorf("--quobyte_version must be 2 for Quobyte 2.x/3 for Quobyte 3.x (given %d)", *quobyteVersion)
+	if *quobyteVersion != 3 && *quobyteVersion != 4 {
+		klog.Errorf("--quobyte_version must be 3 for Quobyte 2.x/4 for Quobyte 4.x (given %d)", *quobyteVersion)
 		os.Exit(1)
 	}
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -29,11 +29,13 @@ var (
 	driverVersion                = flag.String("driver_version", "", "Quobyte CSI driver version")
 	useNameSpaceAsTenant         = flag.Bool("use_k8s_namespace_as_tenant", false, "Uses k8s PVC.namespace as Quobyte tenant")
 	enableQuobyteAccessKeyMounts = flag.Bool("enable_access_key_mounts", false, "Enables use of Quobyte Access keys for mounting volumes")
-	enableVolumeMetrics         = flag.Bool("enable_volume_metrics", true, "Enables volume metrics (space and inodes) export")
+	enableVolumeMetrics          = flag.Bool("enable_volume_metrics", false, "Enables volume metrics (space and inodes) export")
 	immediateErase               = flag.Bool("immediate_erase", false, "Schedules erase volume task immediately (supported from Quobyte 3.x)")
-	quobyteVersion               = flag.Int("quobyte_version", 2, "Specify Quobyte major version (2 for Quobyte 2.x and 3 for Quobyte 3.x)")
-	sharedVolumes                = flag.String("shared_volumes_list", "", "Comma separated list of shared volumes (applicable only for Quobyte 2.x)")
-	parallelDeletions            = flag.Int("parallel_deletions", 10, "Delete 'n' shared volume directories parallelly (effective only for Quobyte 2.x)")
+	quobyteVersion               = flag.Int("quobyte_version", 3, "Specify Quobyte major version (3 for Quobyte 3.x and 4 for Quobyte 4.x)")
+	sharedVolumes                = flag.String("shared_volumes_list", "", "Comma separated list of shared volumes")
+	parallelDeletions            = flag.Int("parallel_deletions", 10, "Delete 'n' shared volume directories parallelly")
+	useDeleteFilesTask           = flag.Bool("use_delete_files_task", false,
+		"Remove shared volume PVCs using delete files task. If disabled, uses rmdir via client mount point")
 )
 
 func main() {
@@ -70,15 +72,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO (venkat): remove cleanup of shared volumes with 2.x deprecation
-	// This is only required for 2.x and cleanup is only run on active controller
-	// and active controller cleans up its own <host_name>_delete_pvc-....> inside shared volume(s) list
-	if *quobyteVersion == 2 && role == Controller {
+	// Cleanup is only run on active controller and active controller cleans up its own
+	// <driverName>_delete_pvc-....> inside shared volume(s) list
+	if role == Controller && !*useDeleteFilesTask {
 		sharedVols := strings.Split(*sharedVolumes, ",")
 		if len(sharedVols) > 0 && *parallelDeletions > 0 {
 			klog.Infof("Shared volumes cleanup is enabled for volumes %s", sharedVols)
 			// run periodic clean up for shared volumes
-			driver.LaunchDirectoryDeleter(*nodeName, *clientMountPoint, sharedVols, *parallelDeletions)
+			driver.LaunchDirectoryDeleter(*driverName, *clientMountPoint, sharedVols, *parallelDeletions)
 		} else {
 			klog.Info("Shared volumes cleanup is turned off")
 		}
@@ -95,7 +96,8 @@ func main() {
 		*enableQuobyteAccessKeyMounts,
 		*immediateErase,
 		*quobyteVersion,
-		*enableVolumeMetrics)
+		*enableVolumeMetrics,
+		*useDeleteFilesTask)
 	err = qd.Run()
 	if err != nil {
 		klog.Errorf("Failed to start Quobyte CSI grpc server due to error: %v.", err)

--- a/src/driver/controller.go
+++ b/src/driver/controller.go
@@ -338,9 +338,9 @@ func (d *QuobyteDriver) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeR
 			err = quobyteClient.EraseVolumeByResolvingNamesToUUID(volumeIdParts[1], volumeIdParts[0], d.ImmediateErase)
 		}
 	} else if len(volumeIdParts) == 3 { // tenant|volume|subdir
-		if d.QuobyteVersion == 2 {
+		if !d.UseDeleteFilesTask {
 			subdirPath := filepath.Join(d.clientMountPoint, volumeIdParts[1], volumeIdParts[2])
-			renameTo := filepath.Join(d.clientMountPoint, volumeIdParts[1], fmt.Sprintf(DELETE_MARKER_FORMAT, d.NodeName, volumeIdParts[2]))
+			renameTo := filepath.Join(d.clientMountPoint, volumeIdParts[1], fmt.Sprintf(DELETE_MARKER_FORMAT, d.Name, volumeIdParts[2]))
 			if err := os.Rename(subdirPath, renameTo); err != nil {
 				if e, ok := err.(*os.LinkError); ok && e.Err != syscall.ENOENT {
 					return nil, fmt.Errorf("Cannot mark directory '%s' for deletion due to %s", subdirPath, err)

--- a/src/driver/driver.go
+++ b/src/driver/driver.go
@@ -109,7 +109,7 @@ func (d *QuobyteDriver) Run() error {
 		}
 		return resp, err
 	}
-	klog.Infof("Starting Quobyte-CSI Driver with %v\n", d)
+	klog.Infof("Starting Quobyte-CSI Driver with %+v\n", d)
 	d.server = grpc.NewServer(grpc.UnaryInterceptor(errHandler))
 	csi.RegisterNodeServer(d.server, d)
 	csi.RegisterControllerServer(d.server, d)

--- a/src/driver/driver.go
+++ b/src/driver/driver.go
@@ -66,6 +66,15 @@ func NewQuobyteDriver(
 	}
 }
 
+func (d *QuobyteDriver) String() string {
+	return fmt.Sprintf("DriverName: %s, Version: %s, socket: %s, ClientMountPoint: %s,"+
+		"NodeName: %s, ApiURL: %s, UseK8SNamespaceAsQuobyteTenant: %t, IsQuobyteAccessKeyMountsEnabled: %t"+
+		"ImmediateErase: %t, QuobyteVersion: %d, EnabledVolumeMetrics: %t, UseDeleteFilesTask: %t",
+		d.Name, d.Version, d.endpoint, d.clientMountPoint, d.NodeName, d.ApiURL, d.UseK8SNamespaceAsQuobyteTenant,
+		d.IsQuobyteAccessKeyMountsEnabled, d.ImmediateErase, d.QuobyteVersion, d.enabledVolumeMetrics,
+		d.UseDeleteFilesTask)
+}
+
 // Run starts the grpc server for the driver
 func (d *QuobyteDriver) Run() error {
 	if len(d.clientMountPoint) == 0 {
@@ -109,7 +118,7 @@ func (d *QuobyteDriver) Run() error {
 		}
 		return resp, err
 	}
-	klog.Infof("Starting Quobyte-CSI Driver with %+v\n", d)
+	klog.Infof("Starting Quobyte-CSI Driver with %s\n", d)
 	d.server = grpc.NewServer(grpc.UnaryInterceptor(errHandler))
 	csi.RegisterNodeServer(d.server, d)
 	csi.RegisterControllerServer(d.server, d)

--- a/src/driver/node_test.go
+++ b/src/driver/node_test.go
@@ -20,10 +20,10 @@ func TestGetNodeInfo(t *testing.T) {
 	d := &QuobyteDriver{}
 	d.NodeName = nodeName
 	got, _ := d.NodeGetInfo(context.TODO(), &csi.NodeGetInfoRequest{})
-	wanted := &csi.NodeGetInfoResponse {
+	wanted := &csi.NodeGetInfoResponse{
 		NodeId: nodeName,
 	}
-	assert.Equal(t, wanted, got);
+	assert.Equal(t, wanted, got)
 }
 
 func TestNodePublishVolume(t *testing.T) {
@@ -48,15 +48,15 @@ func TestNodePublishVolume(t *testing.T) {
 	tenantUuid := "some_tenant_uuid"
 	volumeUuid := "some_volume_uuid"
 	mounter.EXPECT().Mount(gomock.Eq(
-		[]string {"-o", "bind", "/quobyte/client/mountpoint/" + volumeUuid,
-		mountPath})).Return(nil)
+		[]string{"-o", "bind", "/quobyte/client/mountpoint/" + volumeUuid,
+			mountPath})).Return(nil)
 	req = &csi.NodePublishVolumeRequest{}
 	req.TargetPath = mountPath
 	req.VolumeId = tenantUuid + SEPARATOR + volumeUuid
 	got, err = d.NodePublishVolume(context.TODO(), req)
 	assert.Nil(err)
-	wanted := &csi.NodePublishVolumeResponse {}
-	assert.Equal(wanted, got);
+	wanted := &csi.NodePublishVolumeResponse{}
+	assert.Equal(wanted, got)
 
 	// Resolve tenant/volume uuid
 	tenantName := "some_tenant_name"
@@ -67,7 +67,7 @@ func TestNodePublishVolume(t *testing.T) {
 		resolvedVolumeUuid, nil)
 	quobyteClientProvider := mocks.NewMockQuobyteApiClientProvider(ctrl)
 	quobyteClientProvider.EXPECT().NewQuobyteApiClient(gomock.Any(), gomock.Any()).DoAndReturn(
-		func (_ *url.URL, _ map[string]string) (quobyte.ExtendedQuobyteApi, error) {
+		func(_ *url.URL, _ map[string]string) (quobyte.ExtendedQuobyteApi, error) {
 			return quoybteClient, nil
 		}).AnyTimes()
 	d.quoybteClientFactory = quobyteClientProvider
@@ -79,12 +79,12 @@ func TestNodePublishVolume(t *testing.T) {
 	secrets[secretPasswordKey] = "some_management_user_password"
 	req.Secrets = secrets
 	mounter.EXPECT().Mount(gomock.Eq(
-		[]string {"-o", "bind", "/quobyte/client/mountpoint/" + resolvedVolumeUuid,
-		mountPath})).Return(nil)
+		[]string{"-o", "bind", "/quobyte/client/mountpoint/" + resolvedVolumeUuid,
+			mountPath})).Return(nil)
 	got, err = d.NodePublishVolume(context.TODO(), req)
 	assert.Nil(err)
-	wanted = &csi.NodePublishVolumeResponse {}
-	assert.Equal(wanted, got);
+	wanted = &csi.NodePublishVolumeResponse{}
+	assert.Equal(wanted, got)
 
 	// TODO(venkat): Expand tests to cover snapshots, mounting with access keys
 	// mounting subdirs (with/without snapshots)
@@ -109,8 +109,8 @@ func TestNodeUnpublishVolume(t *testing.T) {
 	req = &csi.NodeUnpublishVolumeRequest{}
 	req.TargetPath = unmountPath
 	got, _ = d.NodeUnpublishVolume(context.TODO(), req)
-	wanted := &csi.NodeUnpublishVolumeResponse {}
-	assert.Equal(wanted, got);
+	wanted := &csi.NodeUnpublishVolumeResponse{}
+	assert.Equal(wanted, got)
 }
 
 func TestNodeGetVolumeStats(t *testing.T) {
@@ -120,9 +120,9 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	d.enabledVolumeMetrics = false
 	got, err := d.NodeGetVolumeStats(context.TODO(), &csi.NodeGetVolumeStatsRequest{})
 	assert := assert.New(t)
-	assert.Nil(got);
-	assert.NotNil(err);
-	assert.Contains(err.Error(), "disabled for the Quobyte CSI Driver " + driverName)
+	assert.Nil(got)
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "disabled for the Quobyte CSI Driver "+driverName)
 	d = &QuobyteDriver{}
 	req := &csi.NodeGetVolumeStatsRequest{}
 	d.enabledVolumeMetrics = true
@@ -137,33 +137,33 @@ func TestNodeGetVolumeStats(t *testing.T) {
 	mounter.EXPECT().Statfs(gomock.Eq(mountedPath)).DoAndReturn(
 		func(_ string) (unix.Statfs_t, error) {
 			return unix.Statfs_t{
-				Bsize: 2,
+				Bsize:  2,
 				Blocks: 10,
-				Bfree: 5,
+				Bfree:  5,
 				Bavail: 3,
-				Files: 20,
-				Ffree: 10,
+				Files:  20,
+				Ffree:  10,
 			}, nil
 		})
 	d.mounter = mounter
 	req = &csi.NodeGetVolumeStatsRequest{}
 	req.VolumePath = mountedPath
 	got, _ = d.NodeGetVolumeStats(context.TODO(), req)
-	wanted := &csi.NodeGetVolumeStatsResponse {
-		Usage: []*csi.VolumeUsage {
+	wanted := &csi.NodeGetVolumeStatsResponse{
+		Usage: []*csi.VolumeUsage{
 			{
 				Unit:      csi.VolumeUsage_BYTES,
-				Total: 20, // Blocks * Bsize
-				Used: 10, // (Blocks - Bfree) * Bsize
-				Available: 6, // Bavail * Bsize
+				Total:     20, // Blocks * Bsize
+				Used:      10, // (Blocks - Bfree) * Bsize
+				Available: 6,  // Bavail * Bsize
 			},
 			{
 				Unit:      csi.VolumeUsage_INODES,
-				Total: 20,
-				Used: 10,
+				Total:     20,
+				Used:      10,
 				Available: 10,
 			},
 		},
 	}
-	assert.Equal(wanted, got);
+	assert.Equal(wanted, got)
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,7 @@
 module github.com/quobyte/quobyte-csi-driver
 
-go 1.22.2
+go 1.23.0
+
 toolchain go1.24.1
 
 require (


### PR DESCRIPTION
* Cleanup shared volume with rm command option instead of delete files task
* Provide optional node labels for CSI Driver and pod killer cache
* Upgrade CSI sidecar containers